### PR TITLE
test: add test for ts multilevel sorting

### DIFF
--- a/src/providers/BlockSortProvider.ts
+++ b/src/providers/BlockSortProvider.ts
@@ -1,8 +1,8 @@
-import { Range, Selection, TextDocument } from "vscode";
-import ConfigurationProvider from "./ConfigurationProvider";
-import StringProcessingProvider, { Folding } from "./StringProcessingProvider";
+import { Range, Selection, TextDocument } from 'vscode';
+import ConfigurationProvider from './ConfigurationProvider';
+import StringProcessingProvider, { Folding } from './StringProcessingProvider';
 
-type SortingStrategy = "asc" | "desc" | "ascNatural" | "descNatural";
+type SortingStrategy = 'asc' | 'desc' | 'ascNatural' | 'descNatural';
 
 export default class BlockSortProvider {
   public static sort: Record<SortingStrategy, (a: string, b: string) => number> = {
@@ -15,12 +15,13 @@ export default class BlockSortProvider {
   protected static padNumbers(line: string) {
     const { omitUuids, padding, sortNegativeValues } = ConfigurationProvider.getNaturalSortOptions();
     let result = line;
-    if (omitUuids) result = result.replace(/\d+(?=[^a-zA-z]|$)|(?<=[^a-zA-z]|^)\d+/g, (match) => match.padStart(padding, "0"));
-    else result = result.replace(/\d+/g, (match) => match.padStart(padding, "0"));
+    if (omitUuids)
+      result = result.replace(/\d+(?=[^a-zA-z]|$)|(?<=[^a-zA-z]|^)\d+/g, (match) => match.padStart(padding, '0'));
+    else result = result.replace(/\d+/g, (match) => match.padStart(padding, '0'));
 
     if (sortNegativeValues) {
       result = result.replace(
-        new RegExp(`-\\d{${padding}}`, "g"),
+        new RegExp(`-\\d{${padding}}`, 'g'),
         (match) => `-${(Math.pow(10, padding) + parseInt(match)).toString()}`
       );
     }
@@ -46,20 +47,20 @@ export default class BlockSortProvider {
       textBlocks = textBlocks.map((block) => this.sortBlockHeaders(block, sort));
 
     if (this.stringProcessor.isList(blocks) && textBlocks.length && !/,$/.test(textBlocks[textBlocks.length - 1])) {
-      textBlocks[textBlocks.length - 1] += ",";
+      textBlocks[textBlocks.length - 1] += ',';
       this.applySort(textBlocks, sort);
-      textBlocks[textBlocks.length - 1] = textBlocks[textBlocks.length - 1].replace(/,\s*$/, "");
+      textBlocks[textBlocks.length - 1] = textBlocks[textBlocks.length - 1].replace(/,\s*$/, '');
     } else {
       this.applySort(textBlocks, sort);
     }
 
     if (textBlocks.length && !textBlocks[0].trim()) {
-      textBlocks.push(textBlocks.shift() || "");
+      textBlocks.push(textBlocks.shift() || '');
     } else if (textBlocks.length && /^\s*\r?\n/.test(textBlocks[0])) {
       // For some reason a newline for the second block gets left behind sometimes
       const front = !/\r?\n$/.test(textBlocks[0]) && textBlocks[1] && !/^\r?\n/.test(textBlocks[1]);
-      textBlocks[0] = textBlocks[0].replace(/^\s*\r?\n/, "");
-      textBlocks[front ? 0 : textBlocks.length - 1] += "\n";
+      textBlocks[0] = textBlocks[0].replace(/^\s*\r?\n/, '');
+      textBlocks[front ? 0 : textBlocks.length - 1] += '\n';
     }
 
     return textBlocks;
@@ -69,7 +70,7 @@ export default class BlockSortProvider {
     const startLine = range.start.line;
     const text = this.document.getText(range);
     const lines = text.split(/\r?\n/);
-    const firstLine = lines.shift() || "";
+    const firstLine = lines.shift() || '';
     const initialIndent = this.stringProcessor.getIndent(firstLine);
     const blocks: Range[] = [];
 
@@ -90,7 +91,7 @@ export default class BlockSortProvider {
         blocks.push(this.document.validateRange(new Range(startLine + lastStart, 0, startLine + currentEnd, Infinity)));
         lastStart = currentEnd + 1;
         currentEnd = lastStart;
-        currentBlock = "";
+        currentBlock = '';
         validBlock = false;
       } else {
         currentEnd++;
@@ -125,7 +126,9 @@ export default class BlockSortProvider {
     }
 
     const intersection = block.intersection(new Range(block.start.line + start, 0, block.start.line + end, Infinity));
-    if (intersection && !intersection.isEmpty) return this.getBlocks(intersection);
+    const lineDiff =
+      block.end.line - block.start.line - (intersection ? intersection.end.line - intersection.start.line : 0);
+    if (intersection && !intersection.isEmpty && lineDiff) return this.getBlocks(intersection);
     return [];
   }
 
@@ -185,14 +188,14 @@ export default class BlockSortProvider {
     if (sortChildren === 0) return this.document.getText(block);
 
     let blocks = this.getInnerBlocks(block);
-    if (!blocks.length) return this.document.getText(block);
+    if (blocks.length < 2) return this.document.getText(block);
 
     const head: Range = new Range(block.start, blocks[0]?.start || block.start);
     const tail: Range = new Range(blocks[blocks.length - 1]?.end || block.end, block.end);
 
     return (
       this.document.getText(head) +
-      this.sortBlocks(blocks, sort, sortChildren - 1).join("\n") +
+      this.sortBlocks(blocks, sort, sortChildren - 1).join('\n') +
       this.document.getText(tail)
     );
   }
@@ -211,7 +214,7 @@ export default class BlockSortProvider {
     this.applySort(headers, sort);
     lines = [...headers, ...lines];
 
-    return lines.join("\n");
+    return lines.join('\n');
   }
 
   private applySort(blocks: string[], sort: (a: string, b: string) => number = BlockSortProvider.sort.asc) {

--- a/src/providers/ConfigurationProvider.ts
+++ b/src/providers/ConfigurationProvider.ts
@@ -1,20 +1,20 @@
-import { workspace } from "vscode";
-import { FoldingMarkerDefault, FoldingMarkerList } from "./StringProcessingProvider";
+import { workspace } from 'vscode';
+import { FoldingMarkerDefault, FoldingMarkerList } from './StringProcessingProvider';
 
 const defaultFoldingMarkers: FoldingMarkerList<FoldingMarkerDefault> = {
-  "()": { start: "\\(", end: "\\)" },
-  "[]": { start: "\\[", end: "\\]" },
-  "{}": { start: "\\{", end: "\\}" },
-  "<>": { start: "<[a-zA-Z0-9\\-_=\\s]+", end: "<\\/[a-zA-Z0-9\\-_=\\s]+" },
+  '()': { start: '\\(', end: '\\)' },
+  '[]': { start: '\\[', end: '\\]' },
+  '{}': { start: '\\{', end: '\\}' },
+  '<>': { start: '<[a-zA-Z0-9\\-_=\\s]+', end: '<\\/[a-zA-Z0-9\\-_=\\s]+' },
 };
 
-const defaultCompleteBlockMarkers = ["\\}", "<\\/[a-zA-Z0-9\\-_=\\s]+"];
+const defaultCompleteBlockMarkers = ['\\}', '<\\/[a-zA-Z0-9\\-_=\\s]+'];
 
 const defaultIndentIgnoreMarkers = [
-  "{",
+  '{',
   // eslint-disable-next-line quotes
   "end(?:for(?:each)?|if|while|case|def)?\\s*?([\\.\\[\\->\\|\\s]\\s*(?:[$A-Za-z0-9_+\\-\\*\\/\\^\\%\\<\\>\\=\\!\\?\\:]*|'[^']*?'|'[']*?'|\"[^\"]*?\"|`[^`]*?`)\\s*[\\]\\|]?\\s*)*",
-  "esac|fi",
+  'esac|fi',
 ];
 
 export interface NaturalSortOptions {
@@ -26,65 +26,66 @@ export interface NaturalSortOptions {
 
 export default class ConfigurationProvider {
   public static getFoldingMarkers(): FoldingMarkerList {
-    const additional: FoldingMarkerList = workspace.getConfiguration("blocksort").get("foldingMarkers") || {};
+    const additional: FoldingMarkerList = workspace.getConfiguration('blocksort').get('foldingMarkers') || {};
     return { ...additional, ...defaultFoldingMarkers };
   }
 
   public static getCompleteBlockMarkers(): string[] {
-    const additional: string[] = workspace.getConfiguration("blocksort").get("completeBlockMarkers") || [];
+    const additional: string[] = workspace.getConfiguration('blocksort').get('completeBlockMarkers') || [];
     return [...additional, ...defaultCompleteBlockMarkers];
   }
 
   public static getSortConsecutiveBlockHeaders(): boolean {
     const configuration: boolean | undefined = workspace
-      .getConfiguration("blocksort")
-      .get("sortConsecutiveBlockHeaders");
+      .getConfiguration('blocksort')
+      .get('sortConsecutiveBlockHeaders');
     return configuration === undefined ? true : configuration;
   }
 
   public static getDefaultMultilevelDepth(): number {
-    const configuration: number | undefined = workspace.getConfiguration("blocksort").get("defaultMultilevelDepth");
+    const configuration: number | undefined = workspace.getConfiguration('blocksort').get('defaultMultilevelDepth');
     return configuration === undefined ? -1 : configuration;
   }
 
   public static getAskForMultilevelDepth(): boolean {
-    const configuration: boolean | undefined = workspace.getConfiguration("blocksort").get("askForMultilevelDepth");
+    const configuration: boolean | undefined = workspace.getConfiguration('blocksort').get('askForMultilevelDepth');
     return configuration === undefined ? true : configuration;
   }
 
   public static getForceBlockHeaderFirstRegex(): string {
-    return "$^";
+    return '$^';
   }
 
   public static getForceBlockHeaderLastRegex(): string {
-    return "(default|else)\\s*('([^']|(?<=\\\\)')*'|\"([^\"]|(?<=\\\\)\")*\"|`([^`]|(?<=\\\\)`)*`|[A-Za-z_+\\-*/%<>d.,s]*)*\\s*(.*:)?(\r?\n|$)";
+    return '^(\\s*(when|case)\\s*(\'([^\']|(?<=\\\\)\')*\'|"([^"]|(?<=\\\\)")*"|`([^`]|(?<=\\\\)`)*`|[A-Za-z_+\\-*/%<>d.,s]*)*\\s*(.*:)?\\n?\\r?)*\\s*default|else(?!\\s?if)\\s*:?$';
   }
 
   public static getMultiBlockHeaderRegex(): string {
-    return "(when|case|else|default)\\s*('([^']|(?<=\\\\)')*'|\"([^\"]|(?<=\\\\)\")*\"|`([^`]|(?<=\\\\)`)*`|[A-Za-z_+\\-*/%<>d.,s]*)*\\s*(.*:)?$";
+    return '^(when|case|default|else)\\s*(\'([^\']|(?<=\\\\)\')*\'|"([^"]|(?<=\\\\)")*"|`([^`]|(?<=\\\\)`)*`|[A-Za-z_+\\-*/%<>d.,s]*)*\\s*(.*:)?$';
   }
 
   public static getIncompleteBlockRegex(): string {
-    return "(if|when|else|case|for|foreach|else|elsif|while|def|then)\\s*('([^']|(?<=\\\\)')*'|\"([^\"]|(?<=\\\\)\")*\"|`([^`]|(?<=\\\\)`)*`|[A-Za-z_+\\-*/%<>d.,s]*)*\\s*(.*:)?$";
+    return '(if|when|else|case|for|foreach|else|elsif|while|def|then|default)\\s*(\'([^\']|(?<=\\\\)\')*\'|"([^"]|(?<=\\\\)")*"|`([^`]|(?<=\\\\)`)*`|[A-Za-z_+\\-*/%<>d.,s]*)*\\s*(.*:)?$';
   }
 
   public static getIndentIgnoreMarkers(): string[] {
-    const additional: string[] = workspace.getConfiguration("blocksort").get("indentIgnoreMarkers") || [];
+    const additional: string[] = workspace.getConfiguration('blocksort').get('indentIgnoreMarkers') || [];
     return [...additional, ...defaultIndentIgnoreMarkers];
   }
 
   public static getNaturalSortOptions(): NaturalSortOptions {
-    const configuration:  Partial<NaturalSortOptions> = workspace.getConfiguration("blocksort").get("naturalSorting") || {};
+    const configuration: Partial<NaturalSortOptions> =
+      workspace.getConfiguration('blocksort').get('naturalSorting') || {};
     return {
       enabled: false,
       padding: 9,
       omitUuids: false,
       sortNegativeValues: true,
-      ...configuration
+      ...configuration,
     };
   }
 
   public static getEnableNaturalSorting(): boolean {
-    return !!workspace.getConfiguration("blocksort").get("enableNaturalSorting");
+    return !!workspace.getConfiguration('blocksort').get('enableNaturalSorting');
   }
 }

--- a/src/providers/StringProcessingProvider.ts
+++ b/src/providers/StringProcessingProvider.ts
@@ -110,27 +110,35 @@ export default class StringProcessingProvider {
     return new RegExp(completeBlockRegex, 'g').test(block);
   }
 
-  public isInCompleteBlock(block: string): boolean {
+  public isIncompleteBlock(block: string): boolean {
     const comment = commentRegex[this.document.languageId || 'default'] || commentRegex.default;
-    const blockHeaderRegex = ConfigurationProvider.getIncompleteBlockRegex().replace(/\$$/, `(?:${comment}|\\s*)*$`);
-    return new RegExp(blockHeaderRegex, 'g').test(block);
+    const incompleteBlockRegex = ConfigurationProvider.getIncompleteBlockRegex()
+      .replace(/\$$/, `(?:${comment}|\\s*)*$`)
+      .replace(/^\^/, `^(?:${comment}|\\s*)*`);
+    return new RegExp(incompleteBlockRegex, 'g').test(block);
   }
 
   public isMultiBlockHeader(block: string): boolean {
     const comment = commentRegex[this.document.languageId || 'default'] || commentRegex.default;
-    const blockHeaderRegex = ConfigurationProvider.getMultiBlockHeaderRegex().replace(/\$$/, `(?:${comment}|\\s*)*$`);
+    const blockHeaderRegex = ConfigurationProvider.getMultiBlockHeaderRegex()
+      .replace(/\$$/, `(?:${comment}|\\s*)*$`)
+      .replace(/^\^/, `^(?:${comment}|\\s*)*`);
     return new RegExp(blockHeaderRegex, 'g').test(block);
   }
 
   public isForceFirstBlock(block: string): boolean {
     const comment = commentRegex[this.document.languageId || 'default'] || commentRegex.default;
-    const firstRegex = ConfigurationProvider.getForceBlockHeaderFirstRegex().replace(/\$$/, `(?:${comment}|\\s*)*$`);
+    const firstRegex = ConfigurationProvider.getForceBlockHeaderFirstRegex()
+      .replace(/\$$/, `(?:${comment}|\\s*)*\\n`)
+      .replace(/^\^/, `^(?:${comment}|\\s*)*`);
     return new RegExp(firstRegex, 'g').test(block);
   }
 
   public isForceLastBlock(block: string): boolean {
     const comment = commentRegex[this.document.languageId || 'default'] || commentRegex.default;
-    const lastRegex = ConfigurationProvider.getForceBlockHeaderLastRegex().replace(/\$$/, `(?:${comment}|\\s*)*$`);
+    const lastRegex = ConfigurationProvider.getForceBlockHeaderLastRegex()
+      .replace(/\$$/, `(?:${comment}|\\s*)*\\n`)
+      .replace(/^\^/, `^(?:${comment}|\\s*)*`);
     return new RegExp(lastRegex, 'g').test(block);
   }
 

--- a/src/test/fixtures/multilevel.ts
+++ b/src/test/fixtures/multilevel.ts
@@ -7,4 +7,9 @@ export const multilevelSortTests: SortTest[] = [
     compareFile: 'multilevel.txt.expect',
     ranges: [new Range(0, 0, 16, 8)],
   },
+  {
+    file: 'multilevel.ts.fixture',
+    compareFile: 'multilevel.ts.expect',
+    ranges: [new Range(1, 0, 18, 20)],
+  },
 ];

--- a/src/test/suite/BlockSortProvider.unit.test.ts
+++ b/src/test/suite/BlockSortProvider.unit.test.ts
@@ -1,56 +1,56 @@
-import * as assert from "assert";
-import { join } from "path";
-import { window, workspace, Selection } from "vscode";
-import BlockSortProvider from "../../providers/BlockSortProvider";
-import { expandTests, fixtureDir, sortTests, multilevelSortTests } from "../fixtures";
-import { SortTest } from "./types";
-import { naturalSortTests } from "../fixtures/natural";
+import * as assert from 'assert';
+import { join } from 'path';
+import { window, workspace, Selection } from 'vscode';
+import BlockSortProvider from '../../providers/BlockSortProvider';
+import { expandTests, fixtureDir, sortTests, multilevelSortTests } from '../fixtures';
+import { SortTest } from './types';
+import { naturalSortTests } from '../fixtures/natural';
 
 function sortTest(
   tests: SortTest[],
-  title = "Sort Blocks",
+  title = 'Sort Blocks',
   sort: (a: string, b: string) => number = BlockSortProvider.sort.asc,
   sortChildren = 0
 ) {
   tests.forEach(({ file, compareFile, ranges }) => {
     ranges.forEach((range, i) => {
       const descriptor = file.match(/(.*)\.(.*)\.fixture/);
-      const [_, type, lang] = descriptor || ["", "generic", "generic"];
+      const [_, type, lang] = descriptor || ['', 'generic', 'generic'];
       test(`Sort Blocks (${type}, lang ${lang}) #${i}`, async () => {
         const compareDocument = await workspace.openTextDocument(join(fixtureDir, compareFile));
         const document = await workspace.openTextDocument(join(fixtureDir, file));
         const blockSortProvider = new BlockSortProvider(document);
 
         const blocks = blockSortProvider.getBlocks(range);
-        const sorted = blockSortProvider.sortBlocks(blocks, sort, sortChildren).join("\n");
+        const sorted = blockSortProvider.sortBlocks(blocks, sort, sortChildren).join('\n');
         const compareSorted = compareDocument.getText(range);
 
-        assert.strictEqual(sorted, compareSorted, "sorted ranges are not equal");
+        assert.strictEqual(sorted, compareSorted, 'sorted ranges are not equal');
       });
     });
   });
 }
 
-suite("Unit Suite for BlockSortProvider", async () => {
-  window.showInformationMessage("Start tests for BlockSortProvider.");
+suite('Unit Suite for BlockSortProvider', async () => {
+  window.showInformationMessage('Start tests for BlockSortProvider.');
 
   expandTests.forEach(({ file, ranges, targetRanges }) => {
     ranges
       .map((range, i) => ({ position: range, target: targetRanges[i] }))
       .forEach(({ position, target }, i) => {
-        const [_, lang] = file.match(/\.(.*)\.fixture/) || ["", "generic"];
+        const [_, lang] = file.match(/\.(.*)\.fixture/) || ['', 'generic'];
         test(`Expands selection (lang ${lang}) #${i}`, async () => {
           const document = await workspace.openTextDocument(join(fixtureDir, file));
           const blockSortProvider = new BlockSortProvider(document);
           const selection = new Selection(position.start, position.end);
           const expanded = blockSortProvider.expandSelection(selection);
 
-          assert.deepStrictEqual(expanded, target, "range did not expand correctly");
+          assert.deepStrictEqual(expanded, target, 'range did not expand correctly');
         });
       });
   });
 
-  sortTest(sortTests, "Sort Blocks");
-  sortTest(multilevelSortTests, "Deep Sort Blocks", BlockSortProvider.sort.asc, -1);
-  sortTest(naturalSortTests, "Natural Sort Blocks",  BlockSortProvider.sort.ascNatural, 0);
+  sortTest(sortTests, 'Sort Blocks');
+  sortTest(multilevelSortTests, 'Deep Sort Blocks', BlockSortProvider.sort.asc, -1);
+  sortTest(naturalSortTests, 'Natural Sort Blocks', BlockSortProvider.sort.ascNatural, 0);
 });

--- a/test/fixtures/multilevel.ts.expect
+++ b/test/fixtures/multilevel.ts.expect
@@ -1,0 +1,21 @@
+function test(input: string, select = 0) {
+  switch(input) {
+    case '1':
+      return 'first';
+    case '2':
+      return 'second';
+    case '3':
+      switch (select) {
+        case 8:
+          return 'third-first';
+        case 23:
+          return 'third-second';
+        case 196:
+          return 'third-third';
+        default:
+          return 'third-last';
+      }
+    default:
+      return 'last';
+  }
+}

--- a/test/fixtures/multilevel.ts.expect
+++ b/test/fixtures/multilevel.ts.expect
@@ -6,11 +6,11 @@ function test(input: string, select = 0) {
       return 'second';
     case '3':
       switch (select) {
-        case 8:
+        case 1:
           return 'third-first';
-        case 23:
+        case 2:
           return 'third-second';
-        case 196:
+        case 8:
           return 'third-third';
         default:
           return 'third-last';

--- a/test/fixtures/multilevel.ts.fixture
+++ b/test/fixtures/multilevel.ts.fixture
@@ -1,0 +1,21 @@
+function test(input: string, select = 0) {
+  switch(input) {
+    case '1':
+      return 'first';
+    case '2':
+      return 'second';
+    case '3':
+      switch (select) {
+        case 8:
+          return 'third-first';
+        case 23:
+          return 'third-second';
+        case 196:
+          return 'third-third';
+        default:
+          return 'third-last';
+      }
+    default:
+      return 'last';
+  }
+}

--- a/test/fixtures/multilevel.ts.fixture
+++ b/test/fixtures/multilevel.ts.fixture
@@ -1,20 +1,20 @@
 function test(input: string, select = 0) {
   switch(input) {
-    case '1':
-      return 'first';
     case '2':
       return 'second';
     case '3':
       switch (select) {
-        case 8:
-          return 'third-first';
-        case 23:
+        case 2:
           return 'third-second';
-        case 196:
+        case 1:
+          return 'third-first';
+        case 8:
           return 'third-third';
         default:
           return 'third-last';
       }
+    case '1':
+      return 'first';
     default:
       return 'last';
   }


### PR DESCRIPTION
This pull request is targeted at a bug, which results in the call stack size being exceeded when using multilevel sort with a depth of `-1`. It will also attempt to fix an issue, where a nested blocks get jumbled when using multilevel sorting.

### TODO

- [x] write tests taht reproduce the error
- [x] fix call stack size being exceeded
- [x] fix jumbling of indented blocks