### PR TITLE
Support TypeScript union types

### DIFF
--- a/src/providers/StringProcessingProvider.ts
+++ b/src/providers/StringProcessingProvider.ts
@@ -197,16 +197,16 @@ export default class StringProcessingProvider {
     return null;
   }
 
-  public getBlockSeparator(line: string, currentSeparator?: string): string {
-    if (typeof currentSeparator !== "string") return /[,\r?\n]+$/g.exec(line)?.pop() || "";
-    if (!currentSeparator) return "";
+  public getBlockSeparator(lines: string | string[], allowed: string = ",;", ignoreLast = true): string {
+    if (!allowed) return "";
 
-    const separator = /[,;\r?\n]+$/g.exec(line)?.pop() || "";
-    const index = currentSeparator.indexOf(separator);
+    const separatorRegex = new RegExp(`[${allowed}](?=[\\s\\r\\n]+)?$`, "g");
+    const separators = (typeof lines === "string" ? [lines] : lines).map((line) => line.match(separatorRegex)?.pop());
 
-    if (index < 0) return "";
+    let separator = separators.shift();
+    for (const sep of separators.slice(0, ignoreLast ? -1 : separators.length)) if (sep !== separator) return "";
 
-    return currentSeparator.slice(index);
+    return separator || "";
   }
 
   public stripComments(text: string): string {

--- a/src/providers/StringProcessingProvider.ts
+++ b/src/providers/StringProcessingProvider.ts
@@ -125,7 +125,7 @@ export default class StringProcessingProvider {
   }
 
   public hasFolding(folding: Folding): boolean {
-    for (const key of Object.keys(folding)) if (folding[key].level) return true;
+    for (const { level } of Object.values(folding)) if (level) return true;
 
     return false;
   }

--- a/src/test/fixtures/multilevel.ts
+++ b/src/test/fixtures/multilevel.ts
@@ -10,6 +10,6 @@ export const multilevelSortTests: CompareTest[] = [
   {
     file: "multilevel.typescript.fixture",
     compareFile: "multilevel.typescript.expect",
-    ranges: [new Range(1, 0, 18, 20)],
+    ranges: [new Range(1, 0, 18, 20), new Range(22, 0, 36, 5), new Range(38, 0, 53, 6)],
   },
 ];

--- a/src/test/fixtures/sort.ts
+++ b/src/test/fixtures/sort.ts
@@ -65,7 +65,13 @@ export const sortTests: CompareTest[] = [
   {
     file: "block.go.fixture",
     compareFile: "block.go.expect",
-    ranges: [new Range(1, 0, 3, 10), new Range(7, 0, 9, 10), new Range(13, 0, 15, 10), new Range(18, 0, 27, 1), new Range(29, 0, 38, 1)],
+    ranges: [
+      new Range(1, 0, 3, 10),
+      new Range(7, 0, 9, 10),
+      new Range(13, 0, 15, 10),
+      new Range(18, 0, 27, 1),
+      new Range(29, 0, 38, 1),
+    ],
   },
   {
     file: "block.markdown.fixture",

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -8,6 +8,7 @@ export function run(): Promise<void> {
   const mocha = new Mocha({
     ui: 'tdd',
     color: true,
+    timeout: 10000,
   });
 
   const testsRoot = path.resolve(__dirname, '..');

--- a/test/fixtures/multilevel.typescript.expect
+++ b/test/fixtures/multilevel.typescript.expect
@@ -19,3 +19,35 @@ function test(input: string, select = 0) {
       return 'last';
   }
 }
+
+type Return<T extends any> =
+  | {
+      data: null;
+      error: {
+        details: object;
+        message: string;
+        name: string;
+        status: number;
+      };
+    }
+  | {
+      data: T;
+      error?: undefined;
+      meta?: unknown;
+    }
+
+type Return<T extends any> =
+  | {
+      data: null;
+      error: {
+        details: object;
+        message: string;
+        name: string;
+        status: number;
+      };
+    }
+  | {
+      data: T;
+      error?: undefined;
+      meta?: unknown;
+    };

--- a/test/fixtures/multilevel.typescript.fixture
+++ b/test/fixtures/multilevel.typescript.fixture
@@ -19,3 +19,35 @@ function test(input: string, select = 0) {
       return 'last';
   }
 }
+
+type Return<T extends any> =
+  | {
+      data: T;
+      meta?: unknown;
+      error?: undefined;
+    }
+  | {
+      data: null;
+      error: {
+        status: number;
+        name: string;
+        message: string;
+        details: object;
+      };
+    }
+
+type Return<T extends any> =
+  | {
+      data: T;
+      meta?: unknown;
+      error?: undefined;
+    }
+  | {
+      data: null;
+      error: {
+        status: number;
+        name: string;
+        message: string;
+        details: object;
+      };
+    };


### PR DESCRIPTION
### Fix #93

- adds additional checks for folding when detecting inner blocks
- adds support for outer block separators, like a `;` after union types in typescript